### PR TITLE
Initial documentation test

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,45 @@
+on:
+  push:
+    branches: ["main"]
+    
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        
+      # Build steps
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+      - name: Build
+        run: npx moonwave build --code ./
+        
+      # Upload steps
+      - name: Setup Pages
+        uses: actions/configure-pages@v1
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: build
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/MainModule.lua
+++ b/MainModule.lua
@@ -108,15 +108,28 @@ type EventPayload = {
 	@interface HubOptions
 	
 	.DSN string -- The DSN for the sentry project to send events to
-	.debug boolean? -- Internal debug mode, prints info about the current state of the SDK when set to `true`
+	.debug boolean? -- See [SDK.debug] (must press the "Show Private")
 	
-	.Release string? -- Arbitrary release identifier. Usually in the format `GameName@1.2.3`
-	.Environment string? -- Arbitrary environment identifier. Defaults to `studio` or `live` as appropriate.
+	.Release string? -- See [SDK.Release]
+	.Environment string? -- See [SDK.Environment]
 	
-	.AutoTrackClient boolean? -- When not explicitly set to false, Sentry will automatically monitor the client-side console.
-	.AutoErrorTracking boolean? -- When not explicitly set to false, Sentry will automatically monitor and report console errors.
-	.AutoWarningTracking boolean? -- When not explicitly set to false, Sentry will automatically monitor and report console warnings.
+	.AutoTrackClient boolean? -- See [SDK.AutoTrackClient]
+	.AutoErrorTracking boolean? -- See [SDK.AutoErrorTracking]
+	.AutoWarningTracking boolean? -- See [SDK.AutoWarningTracking]
 ]=]
+
+--[=[
+@within SDK
+@prop debug boolean?
+@private
+
+:::warning
+ This property must be set in [SDK:Init] through the [HubOptions] table.
+:::
+
+Internal debug mode, prints info about the current state of the SDK when set to `true`
+]=]
+
 --[=[
 @within SDK
 @prop Release string?
@@ -136,6 +149,47 @@ organization.
 Using the format `GameName@1.2.3` is recommended, as sentry will treat everything
 after the `@` as the version number, and automatically adapt their UI to this format.
 :::
+]=]
+--[=[
+@within SDK
+@prop Environment string?
+
+:::warning
+ This property must be set in [SDK:Init] through the [HubOptions] table.
+:::
+
+Arbitrary environment identifier. Defaults to `studio` or `live` as appropriate.
+]=]
+
+--[=[
+@within SDK
+@prop AutoTrackClient boolean?
+
+:::warning
+ This property must be set in [SDK:Init] through the [HubOptions] table.
+:::
+
+When not explicitly set to false, Sentry will automatically monitor the client-side console.
+]=]
+--[=[
+@within SDK
+@prop AutoErrorTracking boolean?
+
+:::warning
+ This property must be set in [SDK:Init] through the [HubOptions] table.
+:::
+
+When not explicitly set to false, Sentry will automatically monitor and report console errors.
+]=]
+--[=[
+@within SDK
+@prop AutoWarningTracking boolean?
+
+:::warning
+ This property must be set in [SDK:Init] through the [HubOptions] table.
+:::
+
+When not explicitly set to false, Sentry will automatically monitor and report console warnings.
 ]=]
 
 type HubOptions = {

--- a/MainModule.lua
+++ b/MainModule.lua
@@ -8,12 +8,22 @@ local PlayerService = game:GetService("Players")
 local ScriptContext = game:GetService("ScriptContext")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
+--[=[
+	@class SDK
+]=]
 local SDK = {}
 SDK.__index = SDK
 
+--[=[
+	@class Hub
+	@ignore
+]=]
 local Hub = setmetatable({}, SDK)
 Hub.__index = Hub
 
+--[=[
+	@class Scope
+]=]
 local Scope = {}
 Scope.__index = Scope
 
@@ -92,6 +102,41 @@ type EventPayload = {
 		details: string?,
 	}}?,
 }
+
+--[=[
+	@within SDK
+	@interface HubOptions
+	
+	.DSN string -- The DSN for the sentry project to send events to
+	.debug boolean? -- Internal debug mode, prints info about the current state of the SDK when set to `true`
+	
+	.Release string? -- Arbitrary release identifier. Usually in the format `GameName@1.2.3`
+	.Environment string? -- Arbitrary environment identifier. Defaults to `studio` or `live` as appropriate.
+	
+	.AutoTrackClient boolean? -- When not explicitly set to false, Sentry will automatically monitor the client-side console.
+	.AutoErrorTracking boolean? -- When not explicitly set to false, Sentry will automatically monitor and report console errors.
+	.AutoWarningTracking boolean? -- When not explicitly set to false, Sentry will automatically monitor and report console warnings.
+]=]
+--[=[
+@within SDK
+@prop Release string?
+
+:::warning
+ This property must be set in [SDK:Init] through the [HubOptions] table.
+:::
+
+An arbitrary release identifier, used to determine the current version of the game.
+This can be very useful to track which versions of the game are currently affected.
+
+Should be in the format `GameName@1.2.3` using Semantic Versioning; although this
+is not strictly enforced by the SDK or Sentry. The version must be unique in a sentry
+organization.
+
+:::info
+Using the format `GameName@1.2.3` is recommended, as sentry will treat everything
+after the `@` as the version number, and automatically adapt their UI to this format.
+:::
+]=]
 
 type HubOptions = {
 	DSN: string?,
@@ -389,6 +434,9 @@ function SDK:New()
 	return self
 end
 
+--[=[
+	
+]=]
 function SDK:Init(Options: HubOptions?)
 	if RunService:IsClient() then
 		if not Options or Options.AutoErrorTracking ~= false then


### PR DESCRIPTION
This PR adds basic support for Moonwave documentation, and an automatic GitHub workflow to publish it to a publicly available GitHub Pages webpage.